### PR TITLE
Update Livewire attribute from Rule to Validate

### DIFF
--- a/resources/views/livewire/posts/create.blade.php
+++ b/resources/views/livewire/posts/create.blade.php
@@ -4,7 +4,7 @@ use App\Enums\FeaturedStatus;
 use App\Models\Category;
 use App\Models\Post;
 use App\Models\Tag;
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 use Livewire\Volt\Component;
 use Livewire\WithFileUploads;
 use Mary\Traits\Toast;
@@ -12,31 +12,31 @@ use Mary\Traits\Toast;
 new class extends Component {
     use Toast, WithFileUploads;
 
-    #[Rule('required|int')]
+    #[Validate('required|int')]
     public int $category_id;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public string $title;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public string $slug;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public string $description;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public string $body;
 
-    #[Rule('required|date')]
+    #[Validate('required|date')]
     public string $published_at;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public bool $is_featured;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public array $tags;
 
-    #[Rule('image|max:1024')]
+    #[Validate('image|max:1024')]
     public $image;
 
     public function featured(): array

--- a/resources/views/livewire/posts/edit.blade.php
+++ b/resources/views/livewire/posts/edit.blade.php
@@ -4,7 +4,7 @@ use App\Enums\FeaturedStatus;
 use App\Models\Category;
 use App\Models\Post;
 use App\Models\Tag;
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 use Livewire\Volt\Component;
 use Livewire\WithFileUploads;
 use Mary\Traits\Toast;
@@ -14,31 +14,31 @@ new class extends Component {
 
     public Post $post;
 
-    #[Rule('required|int')]
+    #[Validate('required|int')]
     public int $category_id;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public string $title;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public string $slug;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public string $description;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public string $body;
 
-    #[Rule('required|date')]
+    #[Validate('required|date')]
     public string $published_at;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public bool $is_featured;
 
-    #[Rule('required')]
+    #[Validate('required')]
     public array $tags;
 
-    #[Rule('sometimes|nullable|image|max:1024')]
+    #[Validate('sometimes|nullable|image|max:1024')]
     public $coverImage;
 
     public function mount(): void


### PR DESCRIPTION
As the #[Rule] attribute is deprecated and the #[Validate] attribute introduced let's change it.